### PR TITLE
Changes for the footer

### DIFF
--- a/beamerthemeCERN.sty
+++ b/beamerthemeCERN.sty
@@ -39,7 +39,7 @@
     \column{.45\textwidth}
         \insertshorttitle
     \column{.20\textwidth}
-    DD/MM/YYYY
+        \today
     \column{.1\textwidth}
         \insertpagenumber
     \end{columns}

--- a/template.tex
+++ b/template.tex
@@ -8,7 +8,7 @@
 \usetheme{CERN}
 
 % Preamble
-\title{Stuff we want to talk about}
+\title[]{Stuff we want to talk about}
 \author[A.u.thor]{Guy talking about the stuff \newline \texttt{author@email}}
 \date{\today}
 


### PR DESCRIPTION
- Changed the "DD/MM/YY" string in the footline for a call to the "\today" command, so the date in the footer is the same as the one in the title.
- Forced a blank short title by default, so when entering a long title (i.e., "My super awesome title that is really long. But seriously, it's long"), the title will run over the date in the footer.
  This way, if no short title is specified, nothing will be shown in the footer, preserving the date. 
