### PR TITLE
remove whitespaces from README.md (link rendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 cern-beamer
 ===========
 
-A [Beamer](https://bitbucket.org/rivanvx/beamer/wiki/Home) template mimicking 
-the official [CERN] (www.cern.ch) template for presentations as shown 
-[here] (http://design-guidelines.web.cern.ch/presentations).
+A [Beamer](https://bitbucket.org/rivanvx/beamer/wiki/Home) template mimicking
+the official [CERN](www.cern.ch) template for presentations as shown
+[here](http://design-guidelines.web.cern.ch/presentations).
 
-[CERN] (www.cern.ch) is the source of the images used as ghaphic resources for 
-this theme, and retains the sole copyright of all related imagery. 
-For more information regarding this, please take a look to their 
+[CERN](www.cern.ch) is the source of the images used as ghaphic resources for
+this theme, and retains the sole copyright of all related imagery.
+For more information regarding this, please take a look to their
 [copyright](http://cern.ch/copyright).
 
 Files
@@ -21,5 +21,5 @@ Files
 TODO
 ====
 
- * Find a way to use the original logo files defining an enclosing box with  
-  white background for them 
+ * Find a way to use the original logo files defining an enclosing box with
+   white background for them


### PR DESCRIPTION
Markdown links didn't render correctly on github due to whitespaces between ] and (.